### PR TITLE
Do not use wchar on Windows by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Feedstock license: BSD-3-Clause
 
 Summary: The ADAPTIVE Communication Environment
 
-
+The ADAPTIVE Communication Environment
 
 Current build status
 ====================

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,7 +15,7 @@ echo %SLN_PLAT%
 
 REM Configure step
 cd %ACE_ROOT%
-perl %ACE_ROOT%\bin\mwc.pl -type vs2017 -features "uses_wchar=1,zlib=0,ssl=0,openssl11=0,trio=0,xt=0,fl=0,fox=0,tk=0,qt=0,rapi=0,stlport=0,rwho=0" %WORKSPACE%.mwc
+perl %ACE_ROOT%\bin\mwc.pl -type vs2017 -features "uses_wchar=0,zlib=0,ssl=0,openssl11=0,trio=0,xt=0,fl=0,fox=0,tk=0,qt=0,rapi=0,stlport=0,rwho=0" %WORKSPACE%.mwc
 
 REM Create config.h file
 echo #include "ace/config-windows.h" > %ACE_SOURCE_PATH%\config.h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
       - prefix_perl.patch  # [unix]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx]
 
 requirements:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

When preparing the recipe, I enabled the `uses_wchar` option as I thought it was adding some function definition. Instead, I now realize that it substitutes some existing definitions that use `char`, and so I think that it make more sense to track the same default behavior that the vcpkg port has, i.e. to use normal char definitions by default.  