### PR TITLE
Add run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 1
   run_exports:
-    - {{ pin_subpackage(name, max_pin='x') }}
+    - {{ pin_subpackage(name, max_pin='x.x.x') }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,9 @@ source:
       - fix_macos_rpath.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
 
 requirements:
   build:


### PR DESCRIPTION
As the `ace` package installs a shared library, we should add a `run_exports` to ensure that conda packages that depend on it add it automatically to its `run` dependencies (otherwise you will get linking failures such as https://github.com/traversaro/robotology-superbuild/runs/1811094384?check_suite_focus=true ).

@jwillemsen I assume that major release of ACE do not contain ABI-incompatible changes, but if this is not the case feel free to comment, so we can change the `max_pin` to `x.x` or `x.x.x` .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

